### PR TITLE
Concert Adapter: New Server Adapter

### DIFF
--- a/dev-docs/bidders/concert.md
+++ b/dev-docs/bidders/concert.md
@@ -4,8 +4,11 @@ title: Concert
 description: Prebid Concert Bidder Adaptor
 hide: true
 pbjs: true
+pbs: true
 biddercode: concert
-media_types: banner
+media_types: banner, audio, video
+pbs_app_supported: true
+deals_supported: true
 tcfeu_supported: false
 usp_supported: true
 gpp_supported: true


### PR DESCRIPTION
Updates Concert Adapter docs in conjunction with our new Prebid Server adapter.
[Prebid server adapter PR](https://github.com/voxmedia/prebid-server/pull/1)

## 🏷 Type of documentation
- [x] new bid adapter
- [x] update bid adapter

## 📋 Checklist
- [x] Related pull requests in prebid.js or server are linked -> Paste link in this list or reference it on the PR itself
- [x] For new adapters check [submitting your adapter docs](https://docs.prebid.org/dev-docs/bidder-adaptor.html#submitting-your-adapter)
