### PR TITLE
ConcertAnalyticsAdapter/ConcertBidAdapter: Corrected documentation

### DIFF
--- a/dev-docs/analytics/concert.md
+++ b/dev-docs/analytics/concert.md
@@ -5,7 +5,7 @@ description: Concert Analytics Adapter
 modulecode: concert
 enable_download: false
 prebid_member: false
-tcfeu_supported: true
+tcfeu_supported: false
 usp_supported: true
 gvl_id: N/A
 coppa_supported: false

--- a/dev-docs/bidders/concert.md
+++ b/dev-docs/bidders/concert.md
@@ -9,7 +9,7 @@ biddercode: concert
 media_types: banner, audio, video
 pbs_app_supported: true
 deals_supported: true
-tcfeu_supported: true
+tcfeu_supported: false
 usp_supported: true
 gpp_supported: true
 userIds: sharedId, unifiedId, uid2


### PR DESCRIPTION
In previous documentation updates (#4 and #5) I misunderstood the `tcfeu_supported` tag. After [receiving clarification](https://github.com/prebid/prebid.github.io/pull/5293#pullrequestreview-2162439805) I have updated the documentation to reflect Concert's current support for TCF.

## 🏷 Type of documentation
- [x] text edit only (wording, typos)

## 📋 Checklist
